### PR TITLE
Fix name lookup for the interpolateParam function

### DIFF
--- a/include/Extensions/Interpolators/SPK_GraphInterpolator.h
+++ b/include/Extensions/Interpolators/SPK_GraphInterpolator.h
@@ -596,7 +596,7 @@ namespace SPK
 	template<typename T>
 	inline void GraphInterpolator<T>::interpolateEntry(T& result,const InterpolatorEntry<T>& entry,float ratio) const
 	{
-		interpolateParam(result,entry.y0,entry.y1,ratio);
+		this->interpolateParam(result,entry.y0,entry.y1,ratio);
 	}
 
 	template<typename T>
@@ -647,7 +647,7 @@ namespace SPK
 
 			interpolateEntry(y0, previousEntry, ratioY);
 			interpolateEntry(y1, nextEntry, ratioY);
-			interpolateParam(data, y0, y1, ratioX);
+			this->interpolateParam(data, y0, y1, ratioX);
 		}
 	}
 

--- a/include/Extensions/Interpolators/SPK_RandomInterpolator.h
+++ b/include/Extensions/Interpolators/SPK_RandomInterpolator.h
@@ -161,7 +161,7 @@ namespace SPK
 		for (GroupIterator particleIt(group); !particleIt.end(); ++particleIt)
 		{
 			size_t index = particleIt->getIndex();
-			interpolateParam(data[index],deathValuesData[index],birthValuesData[index],particleIt->getEnergy());
+			this->interpolateParam(data[index],deathValuesData[index],birthValuesData[index],particleIt->getEnergy());
 		}
 	}
 

--- a/include/Extensions/Interpolators/SPK_SimpleInterpolator.h
+++ b/include/Extensions/Interpolators/SPK_SimpleInterpolator.h
@@ -110,7 +110,7 @@ namespace SPK
 	void SimpleInterpolator<T>::interpolate(T* data,Group& group,DataSet* dataSet) const
 	{
 		for (GroupIterator particleIt(group); !particleIt.end(); ++particleIt)
-			interpolateParam(data[particleIt->getIndex()],deathValue,birthValue,particleIt->getEnergy());
+			this->interpolateParam(data[particleIt->getIndex()],deathValue,birthValue,particleIt->getEnergy());
 	}
 }
 


### PR DESCRIPTION
Fixes a few errors like the ones below.

On clang:
```
In file included from spark/src/Core/SPK_Factory.cpp:21:
In file included from spark/include/SPARK.h:33:
spark/include/Extensions/Interpolators/SPK_GraphInterpolator.h:599:3: error: explicit qualification required to use member 'interpolateParam' from dependent base class
	            interpolateParam(result,entry.y0,entry.y1,ratio);
	            ^
```

On gcc:
```
spark/include/Extensions/Interpolators/SPK_GraphInterpolator.h:599:33: error: ‘interpolateParam’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
 599 |                 interpolateParam(result,entry.y0,entry.y1,ratio);
     |                 ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```