### PR TITLE
Define SPK_TRACE_MEMORY only if NDEBUG is defined

### DIFF
--- a/include/Core/SPK_MemoryTracer.h
+++ b/include/Core/SPK_MemoryTracer.h
@@ -22,7 +22,7 @@
 #ifndef H_SPK_MEMORYTRACER
 #define H_SPK_MEMORYTRACER
 
-#ifdef _DEBUG
+#if defined(_DEBUG) || !defined(NDEBUG)
 #define SPK_TRACE_MEMORY
 #endif
 


### PR DESCRIPTION
The macro SPK_TRACE_MEMORY when using the MSVC compiler is only defined if
building in debug mode however when using the gcc or clang compilers it is
defined always. This patch sets the macro to only be defined when building
in debug mode across all compilers.