### PR TITLE
Fix the compile time counter

### DIFF
--- a/include/Core/SPK_Attributes.h
+++ b/include/Core/SPK_Attributes.h
@@ -295,7 +295,7 @@ namespace SPK
 
 	public:
 		template<int n>
-		struct Fields : public sAttr::template spkField<n>
+		struct Fields : public sAttr::template spkField<SPK::meta::CountWrapper<n>>
 		{
 		};
 

--- a/include/Core/SPK_DescriptionDefines.h
+++ b/include/Core/SPK_DescriptionDefines.h
@@ -93,82 +93,83 @@ namespace meta
 		_spk_check ## _t_<typename description_root::parentDescription>::value>::value
 
 #define SPK_REGISTER_DESC_TYPE( _tag_ , _type_ )											\
+		static const unsigned int spk_meta_count_ ## _type_ = GET_COUNT(_tag_);				\
 		template<bool b>																	\
-		struct spk ## _tag_<GET_COUNT(_tag_), b>											\
+		struct spk ## _tag_<SPK::meta::CountWrapper<spk_meta_count_ ## _type_>, b>			\
 		{																					\
 			static const bool isVoid = false;												\
 			typedef _type_ type;															\
 		};																					\
-		INC_COUNT(_tag_)
+		INC_COUNT(_tag_, _type_)
 
 /**
 * @internal
 */
-#define _spk_description_body( ... )														\
-		{																					\
-		private:																			\
-			static description_base* _spk_getDescription(_spk_obj* obj)						\
-			{																				\
-				return &obj->_spk_description_obj;											\
-			}																				\
-			template<typename,typename,typename> friend class SPK::DescriptionBase;			\
-			template<int index, bool unused = true>											\
-			struct spkAttr																	\
-			{																				\
-				static const bool isVoid = true;											\
-				typedef SPK::DefaultAttribute<_spk_obj> type;								\
-			};																				\
-			MAKE_COUNTER(Attr);																\
-																							\
-			template<int index, bool unused = true>											\
-			struct spkCtrl																	\
-			{																				\
-				static const bool isVoid = true;											\
-				typedef SPK::DefaultControl<_spk_obj> type;									\
-			};																				\
-			MAKE_COUNTER(Ctrl);																\
-																							\
-			/* Workaround for VS2003-2012 : the following structure (Instantiate)         */\
-			/* triggers infinite inheritance if used in class template and defined        */\
-			/* outside it. See the following page:                                        */\
-			/*http://stackoverflow.com/questions/15620686/templated-recurrent-type-error  */\
-			template<template<int,bool=true> class A, int n = 0, bool = A<n>::isVoid>		\
-			struct Instantiate : public Instantiate<A, n+1>									\
-			{																				\
-				typedef typename A<n>::type type;											\
-				type object;																\
-				using Instantiate<A, n+1>::getObject;										\
-				Instantiate() : object() {}													\
-				type* getObject(SPK::meta::NumOverload<n>)									\
-				{																			\
-					return &object;															\
-				}																			\
-			};																				\
-			template<template<int,bool> class A, int n>										\
-			struct Instantiate<A, n, true>													\
-			{																				\
-				void getObject();															\
-			};																				\
-		public:																				\
-			__VA_ARGS__																		\
-		private:																			\
-			Instantiate<spkAttr> _spk_attributes;											\
-			template<int n>																	\
-			typename spkAttr<n>::type* getAttributePtr()									\
-			{																				\
-				return _spk_attributes.getObject(SPK::meta::NumOverload<n>());				\
-			}																				\
-		};																					\
-	public:																					\
-		class description : public description_base											\
-		{																					\
-		public:																				\
-			static const char* getClassName()												\
-			{																				\
-				return _spk_inner_name::get();												\
-			}																				\
-		};																					\
-	private:																				\
+#define _spk_description_body( ... )																				\
+		{																											\
+		private:																									\
+			static description_base* _spk_getDescription(_spk_obj* obj)												\
+			{																										\
+				return &obj->_spk_description_obj;																	\
+			}																										\
+			template<typename,typename,typename> friend class SPK::DescriptionBase;									\
+			template<typename CW, bool unused = true>																\
+			struct spkAttr																							\
+			{																										\
+				static const bool isVoid = true;																	\
+				typedef SPK::DefaultAttribute<_spk_obj> type;														\
+			};																										\
+			MAKE_COUNTER(Attr);																						\
+																													\
+			template<typename CW, bool unused = true>																\
+			struct spkCtrl																							\
+			{																										\
+				static const bool isVoid = true;																	\
+				typedef SPK::DefaultControl<_spk_obj> type;															\
+			};																										\
+			MAKE_COUNTER(Ctrl);																						\
+																													\
+			/* Workaround for VS2003-2012 : the following structure (Instantiate)         */						\
+			/* triggers infinite inheritance if used in class template and defined        */						\
+			/* outside it. See the following page:                                        */						\
+			/*http://stackoverflow.com/questions/15620686/templated-recurrent-type-error  */						\
+			template<template<typename,bool=true> class A, int n = 0, bool = A<SPK::meta::CountWrapper<n>>::isVoid>	\
+			struct Instantiate : public Instantiate<A, n+1>															\
+			{																										\
+				typedef typename A<SPK::meta::CountWrapper<n>>::type type;											\
+				type object;																						\
+				using Instantiate<A, n+1>::getObject;																\
+				Instantiate() : object() {}																			\
+				type* getObject(SPK::meta::NumOverload<n>)															\
+				{																									\
+					return &object;																					\
+				}																									\
+			};																										\
+			template<template<typename,bool> class A, int n>														\
+			struct Instantiate<A, n, true>																			\
+			{																										\
+				void getObject();																					\
+			};																										\
+		public:																										\
+			__VA_ARGS__																								\
+		private:																									\
+			Instantiate<spkAttr> _spk_attributes;																	\
+			template<int n>																							\
+			typename spkAttr<SPK::meta::CountWrapper<n>>::type* getAttributePtr()									\
+			{																										\
+				return _spk_attributes.getObject(SPK::meta::NumOverload<n>());										\
+			}																										\
+		};																											\
+	public:																											\
+		class description : public description_base																	\
+		{																											\
+		public:																										\
+			static const char* getClassName()																		\
+			{																										\
+				return _spk_inner_name::get();																		\
+			}																										\
+		};																											\
+	private:																										\
 		description_base _spk_description_obj
 
 /**
@@ -306,7 +307,7 @@ namespace meta
 				unsigned int>																\
 			friend class SPK::StructuredAttributeBase;										\
 																							\
-			template<int index, bool unused = true>											\
+			template<typename CW, bool unused = true>										\
 			struct spkField																	\
 			{																				\
 				static const bool isVoid = true;											\

--- a/include/Core/SPK_Meta.h
+++ b/include/Core/SPK_Meta.h
@@ -417,6 +417,12 @@ namespace meta
 	template<int n> struct Counter : public Counter<n-1> {};
 	template<> struct Counter<0> {};
 
+	template<unsigned int n>
+	struct CountWrapper
+	{
+		static const unsigned int value = n;
+	};
+
 	// Create a counter
 #define MAKE_COUNTER( _tag_ ) \
 		static SPK::meta::Count<1> _spk_count_ ## _tag_ (SPK::meta::Counter<1>)
@@ -424,8 +430,9 @@ namespace meta
 	// Use counter
 #define GET_COUNT( _tag_ ) \
 		((sizeof(_spk_count_ ## _tag_ (SPK::meta::Counter<MAX_COUNT + 1>())) / sizeof(bool)) - 1)
-#define INC_COUNT( _tag_ ) \
-		static SPK::meta::Count<GET_COUNT(_tag_) + 2> _spk_count_ ## _tag_ (SPK::meta::Counter<GET_COUNT(_tag_) + 2>)
+#define INC_COUNT( _tag_, _uniqueid_ ) \
+		static const unsigned int spk_meta_inc_count_ ## _uniqueid_ = GET_COUNT(_tag_); \
+		static SPK::meta::Count<spk_meta_inc_count_ ## _uniqueid_ + 2> _spk_count_ ## _tag_ (SPK::meta::Counter<spk_meta_inc_count_ ## _uniqueid_ + 2>)
 }
 }
 
@@ -475,6 +482,6 @@ namespace meta
 		static const bool isVoid = false;													\
 		typedef BaseTypeRelation<_cpp_, _base_, cpp_name, spk_name, _passtype_> type;		\
 	};																						\
-	INC_COUNT(type_relation)
+	INC_COUNT(type_relation, _base_)
 
 #endif

--- a/include/Core/SPK_StaticDescription.h
+++ b/include/Core/SPK_StaticDescription.h
@@ -219,11 +219,11 @@ namespace SPK
 	private:
 		// Array of controls
 		template<int n>
-		struct Controls : public T::template spkCtrl<n,true> {};
+		struct Controls : public T::template spkCtrl<SPK::meta::CountWrapper<n>,true> {};
 
 		// Array of attributes
 		template<int n>
-		struct Attributes : public T::template spkAttr<n,true> {};
+		struct Attributes : public T::template spkAttr<SPK::meta::CountWrapper<n>,true> {};
 
 		/**
 		* @brief Holds the 'queries' allowing to get / alter information on controls and attributes


### PR DESCRIPTION
The compile time counter now compiles with the latest versions of gcc, clang and msvc.