### PR TITLE
Fix put32 function on big endian

### DIFF
--- a/include/Core/IO/SPK_IO_Buffer.h
+++ b/include/Core/IO/SPK_IO_Buffer.h
@@ -79,9 +79,14 @@ namespace IO
 		void put32(int32 i)
 		{
 			if (USE_LITTLE_ENDIANS)
+			{
 				put(reinterpret_cast<char*>(&i),4);
+			}
 			else
-				put(reinterpret_cast<char*>(swap32(i)),4);
+			{
+				int32 swapped = swap32(i);
+				put(reinterpret_cast<char*>(&swapped),4);
+			}
 		}
 
 		////////////////////////////


### PR DESCRIPTION
When compiling with msvc the following warning is shown:

```
spark\include\Core\IO\SPK_IO_Buffer.h(87,1): warning C4312: 'reinterpret_cast': conversion from 'SPK::int32' to 'char *' of greater size
  SPK_IO_Manager.cpp
```

This is due to a bug where the value of the integer (instead of it's address)
is being converted to a pointer.