### PR TITLE
Fix dll linkage on mingw64

### DIFF
--- a/include/Core/SPK_Emitter.h
+++ b/include/Core/SPK_Emitter.h
@@ -57,13 +57,13 @@ namespace SPK
 		*
 		* @param active : true to activate this emitter, false to deactivate it
 		*/
-		void setActive(bool active);
+		inline void setActive(bool active);
 
 		/**
 		* @brief Tells whether this emitter is active or not
 		* @return true if this emitter is active, false if is is inactive
 		*/
-		bool isActive() const;
+		inline bool isActive() const;
 
 		//////////
 		// Tank //
@@ -82,7 +82,7 @@ namespace SPK
 		*
 		* @param tank : the initial number of particles in this emitters's tank
 		*/
-		void setTank(int tank);
+		inline void setTank(int tank);
 
 		/**
 		* @brief Sets the min and max number of particles in this emitter's tank
@@ -100,25 +100,25 @@ namespace SPK
 		* @brief Gets the current number of particles in this emitter's tank
 		* @return the current number of particles in this emitters's tank
 		*/
-		int getCurrentTank() const;
+		inline int getCurrentTank() const;
 
 		/**
 		* @brief Gets the minimum initial number of particles in this emitter's tank
 		* @return the minimum initial number of particles in this emitters's tank
 		*/
-		int getMinTank() const;
+		inline int getMinTank() const;
 
 		/**
 		* @brief Gets the maximum initial number of particles in this emitter's tank
 		* @return the maximum initial number of particles in this emitters's tank
 		*/
-		int getMaxTank() const;
+		inline int getMaxTank() const;
 
 		/**
 		* @brief Resets the current tank
 		* The current tank is reevaluated between the min and max tank
 		*/
-		void resetTank();
+		inline void resetTank();
 
 		//////////
 		// Flow //
@@ -140,7 +140,7 @@ namespace SPK
 		* @brief Gets the flow of this emitter
 		* @return the flow of this emitter
 		*/
-		float getFlow() const;
+		inline float getFlow() const;
 
 		///////////
 		// Force //
@@ -163,13 +163,13 @@ namespace SPK
 		* @brief Gets the minimum force of this emitter
 		* @return the minimum force of this emitter
 		*/
-		float getForceMin() const;
+		inline float getForceMin() const;
 
 		/**
 		* @brief Gets the maximum force of this emitter
 		* @return the maximum force of this emitter
 		*/
-		float getForceMax() const;
+		inline float getForceMax() const;
 		
 		//////////
 		// Zone //
@@ -183,22 +183,22 @@ namespace SPK
 		* @param zone : the zone of this emitter
 		* @param full : true to generate particles in the whole Zone, false to generate particles only at the zone's borders.
 		*/
-		void setZone(const Ref<Zone>& zone, bool full);
+		inline void setZone(const Ref<Zone>& zone, bool full);
 		
 		void setZone(const Ref<Zone>& zone);
-		void setUseFullZone(bool f);
+		inline void setUseFullZone(bool f);
 
 		/**
 		* @brief Gets the zone of this emitter
 		* @return the zone of this emitter
 		*/
-		const Ref<Zone>& getZone() const;
+		inline const Ref<Zone>& getZone() const;
 
 		/**
 		* @brief Tells whether this emitter emits in the whole Zone or only at its borders
 		* @return true if this emitter emits in the whole Zone, false if it is only at its borders
 		*/
-		bool isFullZone() const;
+		inline bool isFullZone() const;
 
 		virtual Ref<SPKObject> findByName(const std::string& name);
 
@@ -245,8 +245,8 @@ namespace SPK
 		
 		void emit(Particle& particle) const;
 
-		size_t updateTankFromTime(float deltaTime);
-		size_t updateTankFromNb(size_t nb);
+		inline size_t updateTankFromTime(float deltaTime);
+		inline size_t updateTankFromNb(size_t nb);
 
 		/**
 		* @brief Gives the particle an initial velocity

--- a/include/Core/SPK_Group.h
+++ b/include/Core/SPK_Group.h
@@ -58,38 +58,38 @@ namespace SPK
 
 	public :
 
-		static Ref<Group> create(size_t capacity = 100);
+		inline static Ref<Group> create(size_t capacity = 100);
 		~Group();
 
-		bool isInitialized() const;
+		inline bool isInitialized() const;
 
 		void setLifeTime(float minLife,float maxLife);
-		void setImmortal(bool immortal);
-		void setStill(bool still);
+		inline void setImmortal(bool immortal);
+		inline void setStill(bool still);
 
 		void setColorInterpolator(const Ref<ColorInterpolator>& interpolator);
-		const Ref<ColorInterpolator>& getColorInterpolator() const;
+		inline const Ref<ColorInterpolator>& getColorInterpolator() const;
 
 		void setParamInterpolator(Param param,const Ref<FloatInterpolator>& interpolator);
-		const Ref<FloatInterpolator>& getParamInterpolator(Param param) const;
+		inline const Ref<FloatInterpolator>& getParamInterpolator(Param param) const;
 
-		void setScaleInterpolator(const Ref<FloatInterpolator>& interpolator);
-		void setMassInterpolator(const Ref<FloatInterpolator>& interpolator);
-		void setAngleInterpolator(const Ref<FloatInterpolator>& interpolator);
-		void setTextureIndexInterpolator(const Ref<FloatInterpolator>& interpolator);
-		void setRotationSpeedInterpolator(const Ref<FloatInterpolator>& interpolator);
-		const Ref<FloatInterpolator>& getScaleInterpolator() const;
-		const Ref<FloatInterpolator>& getMassInterpolator() const;
-		const Ref<FloatInterpolator>& getAngleInterpolator() const;
-		const Ref<FloatInterpolator>& getTextureIndexInterpolator() const;
-		const Ref<FloatInterpolator>& getRotationSpeedInterpolator() const;
+		inline void setScaleInterpolator(const Ref<FloatInterpolator>& interpolator);
+		inline void setMassInterpolator(const Ref<FloatInterpolator>& interpolator);
+		inline void setAngleInterpolator(const Ref<FloatInterpolator>& interpolator);
+		inline void setTextureIndexInterpolator(const Ref<FloatInterpolator>& interpolator);
+		inline void setRotationSpeedInterpolator(const Ref<FloatInterpolator>& interpolator);
+		inline const Ref<FloatInterpolator>& getScaleInterpolator() const;
+		inline const Ref<FloatInterpolator>& getMassInterpolator() const;
+		inline const Ref<FloatInterpolator>& getAngleInterpolator() const;
+		inline const Ref<FloatInterpolator>& getTextureIndexInterpolator() const;
+		inline const Ref<FloatInterpolator>& getRotationSpeedInterpolator() const;
 
-		float getMinLifeTime() const;
-		float getMaxLifeTime() const;
-		bool isImmortal() const;
-		bool isStill() const;
+		inline float getMinLifeTime() const;
+		inline float getMaxLifeTime() const;
+		inline bool isImmortal() const;
+		inline bool isStill() const;
 
-		bool isEnabled(Param param) const;
+		inline bool isEnabled(Param param) const;
 
 		size_t getNbParticles() const;
 		size_t getCapacity() const;
@@ -102,35 +102,35 @@ namespace SPK
 
 		void addEmitter(const Ref<Emitter>& emitter);
 		void removeEmitter(const Ref<Emitter>& emitter);
-		void removeAllEmitters();
-		const Ref<Emitter>& getEmitter(size_t index) const;
-		size_t getNbEmitters() const;
+		inline void removeAllEmitters();
+		inline const Ref<Emitter>& getEmitter(size_t index) const;
+		inline size_t getNbEmitters() const;
 
 		void addModifier(const Ref<Modifier>& modifier);
 		void removeModifier(const Ref<Modifier>& modifier);
 		void removeAllModifiers();
-		const Ref<Modifier>& getModifier(size_t index) const;
-		size_t getNbModifiers() const;
+		inline const Ref<Modifier>& getModifier(size_t index) const;
+		inline size_t getNbModifiers() const;
 
 		void setRenderer(const Ref<Renderer>& renderer);
-		const Ref<Renderer>& getRenderer() const;
+		inline const Ref<Renderer>& getRenderer() const;
 
-		void enableDistanceComputation(bool distanceComputation);
-		bool isDistanceComputationEnabled() const;
+		inline void enableDistanceComputation(bool distanceComputation);
+		inline bool isDistanceComputationEnabled() const;
 
-		void enableSorting(bool sorting);
-		bool isSortingEnabled() const;
+		inline void enableSorting(bool sorting);
+		inline bool isSortingEnabled() const;
 
-		const void* getColorAddress() const;
-		const void* getPositionAddress() const;
-		const void* getVelocityAddress() const;
-		const void* getParamAddress(Param param) const;
+		inline const void* getColorAddress() const;
+		inline const void* getPositionAddress() const;
+		inline const void* getVelocityAddress() const;
+		inline const void* getParamAddress(Param param) const;
 
-		void setRadius(float radius);
+		inline void setRadius(float radius);
 		void setGraphicalRadius(float radius);
 		void setPhysicalRadius(float radius);
-		float getGraphicalRadius() const;
-		float getPhysicalRadius() const;
+		inline float getGraphicalRadius() const;
+		inline float getPhysicalRadius() const;
 
 		/**
 		* @brief Gets a Vector3D holding the minimum coordinates of the AABB of the Group.
@@ -139,7 +139,7 @@ namespace SPK
 		*
 		* @return a Vector3D holding the minimum coordinates of the AABB of the Group
 		*/
-		const Vector3D& getAABBMin() const;
+		inline const Vector3D& getAABBMin() const;
 
 		/**
 		* @brief Gets a Vector3D holding the maximum coordinates of the AABB of the Group.
@@ -148,7 +148,7 @@ namespace SPK
 		*
 		* @return a Vector3D holding the maximum coordinates of the AABB of the Group
 		*/
-		const Vector3D& getAABBMax() const;
+		inline const Vector3D& getAABBMax() const;
 
 		///////////////////
 		// Add Particles //
@@ -176,7 +176,7 @@ namespace SPK
 		* @param position : the position where the Particles will be added
 		* @param velocity : the velocity of the Particles
 		*/
-		void addParticles(unsigned int nb,const Vector3D& position,const Vector3D& velocity);
+		inline void addParticles(unsigned int nb,const Vector3D& position,const Vector3D& velocity);
 
 		/**
 		* @brief Adds some Particles to this Group
@@ -292,7 +292,7 @@ namespace SPK
 
 		void flushBufferedParticles();
 
-		Ref<System> getSystem() const;
+		inline Ref<System> getSystem() const;
 
 		/////////////
 		// Actions //
@@ -303,10 +303,10 @@ namespace SPK
 		*
 		*/
 		void setBirthAction(const Ref<Action>& action);
-		const Ref<Action>& getBirthAction() const;
+		inline const Ref<Action>& getBirthAction() const;
 
 		void setDeathAction(const Ref<Action>& action);
-		const Ref<Action>& getDeathAction() const;
+		inline const Ref<Action>& getDeathAction() const;
 
 		//////////////////////
 		// Advanced methods //
@@ -334,25 +334,25 @@ namespace SPK
 		* @brief Gets the data set used by the interpolator of the given parameter
 		* @return the data set or NULL if the interpolator does not use data set or does not exist
 		*/
-		DataSet* getParamInterpolatorDataSet(Param param);
+		inline DataSet* getParamInterpolatorDataSet(Param param);
 
 		/**
 		* @brief Gets the data set used by the color interpolator
 		* @return the data set or NULL if the color interpolator does not use data set or does not exist
 		*/
-		DataSet* getColorInterpolatorDataSet();
+		inline DataSet* getColorInterpolatorDataSet();
 
 		/**
 		* @brief Gets the data set used by the renderer
 		* @return the data set or NULL if the renderer does not use data set or does not exist
 		*/
-		DataSet* getRendererDataSet();
+		inline DataSet* getRendererDataSet();
 
 		/**
 		* @brief Gets the render buffer
 		* @return the render buffer or NULL if the group does not use a render buffer
 		*/
-		RenderBuffer* getRenderBuffer();
+		inline RenderBuffer* getRenderBuffer();
 
 		/**
 		* @brief Gets the octree

--- a/include/Core/SPK_Logger.h
+++ b/include/Core/SPK_Logger.h
@@ -159,7 +159,7 @@ namespace SPK
 		*
 		* @param enabled : true to enable the logger, false to disable it
 		*/
-		void setEnabled(bool enabled);
+		inline void setEnabled(bool enabled);
 
 		/**
 		* @brief Sets the priority level of the logger
@@ -169,7 +169,7 @@ namespace SPK
 		*
 		* @param priorityLevel : the priority level of the logger
 		*/
-		void setPriorityLevel(LogPriority priorityLevel);
+		inline void setPriorityLevel(LogPriority priorityLevel);
 
 		/**
 		* @brief Sets the inner stream of the logger
@@ -179,7 +179,7 @@ namespace SPK
 		*
 		* @param stream : the inner stream of the logger
 		*/
-		void setStream(std::ostream& stream);
+		inline void setStream(std::ostream& stream);
 
 		/**
 		* @brief Sets the prefix flag of the logger
@@ -190,7 +190,7 @@ namespace SPK
 		*
 		* @param prefixFlag : the prefix flag of the logger 
 		*/
-		void setPrefixFlag(int prefixFlag);
+		inline void setPrefixFlag(int prefixFlag);
 
 		/////////////
 		// Getters //
@@ -200,13 +200,13 @@ namespace SPK
 		* @brief Tells whether the logger is enabled or not
 		* @return true if the logger is enabled, false if it is disabled
 		*/
-		bool isEnabled() const;
+		inline bool isEnabled() const;
 
 		/**
 		* @brief Gets the priority level of the logger
 		* @return the priority level of the logger
 		*/
-		LogPriority getPriorityLevel() const;
+		inline LogPriority getPriorityLevel() const;
 
 		/**
 		* @brief Gets the stream of the logger
@@ -226,7 +226,7 @@ namespace SPK
 		* @brief Gets the prefix flag of the logger
 		* @return the prefix flag of the logger
 		*/
-		int getPrefixFlag() const;
+		inline int getPrefixFlag() const;
 		
 		///////////////
 		// Interface //
@@ -241,10 +241,10 @@ namespace SPK
 		* @param priority : the priority level of the entry
 		* @param entry : the entry to log in
 		*/
-		void addEntry(LogPriority priority,const std::string& entry);
+		inline void addEntry(LogPriority priority,const std::string& entry);
 
 		/** @brief Flushes the logger (Immediately appends pending entries to the inner stream) */
-		void flush();
+		inline void flush();
 
 		//////////////////
 		// Nested class //

--- a/include/Core/SPK_Object.h
+++ b/include/Core/SPK_Object.h
@@ -59,14 +59,14 @@ namespace SPK
 		* When the number of references reaches 0, the object is destroyed.
 		* @return the number of references
 		*/
-		unsigned int getNbReferences() const;
+		inline unsigned int getNbReferences() const;
 
 		/**
 		* Tells whether this object is shared or not
 		* During a deep copy, a referenced shared object will not be copied but only its reference will.
 		* @return true if the object is shared, false otherwise
 		*/
-		bool isShared() const;
+		inline bool isShared() const;
 
 		/**
 		* Sets whether this object is shareable or not
@@ -83,13 +83,13 @@ namespace SPK
 		* @brief Sets the name of this object
 		* @param name : the name
 		*/
-		void setName(const std::string& name);
+		inline void setName(const std::string& name);
 
 		/**
 		* @brief Gets the name of this object
 		* @return the name
 		*/
-		const std::string& getName() const;
+		inline const std::string& getName() const;
 
 		/**
 		* @brief Traverses this object to find an object with the given name

--- a/include/Core/SPK_Renderer.h
+++ b/include/Core/SPK_Renderer.h
@@ -78,9 +78,9 @@ namespace SPK
 		*/
 		static void useVBOHint(bool hint);
 
-		virtual void enableRenderingOption(RenderingOption option,bool enable);
-		virtual void setAlphaTestThreshold(float alphaThreshold);
-		void setActive(bool active);
+		inline virtual void enableRenderingOption(RenderingOption option,bool enable);
+		inline virtual void setAlphaTestThreshold(float alphaThreshold);
+		inline void setActive(bool active);
 		virtual void setBlendMode(BlendMode blendMode) = 0;
 		
 		/////////////
@@ -91,21 +91,21 @@ namespace SPK
 		* Gets the shader hint
 		* @return : the shader hint
 		*/
-		static ShaderHint getShaderHint();
+		inline static ShaderHint getShaderHint();
 
 		/**
 		* Gets the vbo hint
 		* @return : the vbo hint
 		*/
-		static bool getVBOHint();
+		inline static bool getVBOHint();
 
-		virtual bool isRenderingOptionEnabled(RenderingOption option) const;
-		virtual float getAlphaTestThreshold() const;
-		bool isActive() const;
+		inline virtual bool isRenderingOptionEnabled(RenderingOption option) const;
+		inline virtual float getAlphaTestThreshold() const;
+		inline bool isActive() const;
 
 	public : /// TODO: make this private
-		void setRenderingOptions(unsigned int r);
-		unsigned int getRenderingOptions() const;
+		inline void setRenderingOptions(unsigned int r);
+		inline unsigned int getRenderingOptions() const;
 
 	public :
 		spark_description(Renderer, SPKObject)
@@ -133,7 +133,7 @@ namespace SPK
 		int renderingOptionsMask;
 		float alphaThreshold;
 
-		virtual  RenderBuffer* attachRenderBuffer(const Group& group) const;
+		inline virtual  RenderBuffer* attachRenderBuffer(const Group& group) const;
 
 		virtual  void init(const Particle& particle,DataSet* dataSet) const {};
 		virtual  void update(const Group& group,DataSet* dataSet) const {};

--- a/include/Core/SPK_System.h
+++ b/include/Core/SPK_System.h
@@ -66,7 +66,7 @@ namespace SPK
 		// Constructor/Desctructor //
 		/////////////////////////////
 
-		static Ref<System> create(bool initialize = true);
+		inline static Ref<System> create(bool initialize = true);
 		~System();
 
 		////////////////////////////
@@ -76,7 +76,7 @@ namespace SPK
 		/**
 		* @brief Adds a controller to the system
 		*/
-		void addController(const Ref<Controller>& ctrl);
+		inline void addController(const Ref<Controller>& ctrl);
 
 		/**
 		* @brief Removes a controller from the system
@@ -86,17 +86,17 @@ namespace SPK
 		/**
 		* @brief Removes all controllers in the system
 		*/
-		void removeAllControllers();
+		inline void removeAllControllers();
 
 		/**
 		* @brief Returns the i-th controller
 		*/
-		const Ref<Controller>& getController(size_t i) const;
+		inline const Ref<Controller>& getController(size_t i) const;
 
 		/**
 		* @brief Returns the number of controllers in the system
 		*/
-		size_t getNbControllers() const;
+		inline size_t getNbControllers() const;
 
 		///////////////////////
 		// Groups management //
@@ -128,20 +128,20 @@ namespace SPK
 		/**
 		* @brief Removes all groups in this system
 		*/
-		void removeAllGroups();
+		inline void removeAllGroups();
 
 		/**
 		* @brief Gets the group at index
 		* @param index : the index of the group to get
 		* @return the group at index
 		*/
-		const Ref<Group>& getGroup(size_t index) const;
+		inline const Ref<Group>& getGroup(size_t index) const;
 
 		/**
 		* @brief Gets the number of groups in the system
 		* @return the number of groups in the system
 		*/
-		size_t getNbGroups() const;
+		inline size_t getNbGroups() const;
 
 		/**
 		* @brief Gets the number of particles in the system
@@ -179,13 +179,13 @@ namespace SPK
 		* @brief Enables or disables the computation of the axis aligned bounding box for this System
 		* @param AABB : true to enable the computing of the AABB of this System, false to disable it
 		*/
-		void enableAABBComputation(bool AABB);
+		inline void enableAABBComputation(bool AABB);
 
 		/**
 		* @brief Tells whether the computation of the axis aligned bouding box is enabled
 		* @return true if the computation of the AABB is enabled, false if it is disabled
 		*/
-		bool isAABBComputationEnabled() const;
+		inline bool isAABBComputationEnabled() const;
 
 		/**
 		* @brief Gets a Vector3D holding the minimum coordinates of the AABB of this System.
@@ -194,7 +194,7 @@ namespace SPK
 		*
 		* @return a Vector3D holding the minimum coordinates of the AABB of this System
 		*/
-		const Vector3D& getAABBMin() const;
+		inline const Vector3D& getAABBMin() const;
 
 		/**
 		* @brief Gets a Vector3D holding the maximum coordinates of the AABB of this System.
@@ -203,7 +203,7 @@ namespace SPK
 		*
 		* @return a Vector3D holding the maximum coordinates of the AABB of this System
 		*/
-		const Vector3D& getAABBMax() const;
+		inline const Vector3D& getAABBMax() const;
 
 		/////////////////////
 		// Camera position //
@@ -218,13 +218,13 @@ namespace SPK
 		*
 		* @param cameraPosition the camera position
 		*/
-		void setCameraPosition(const Vector3D& cameraPosition);
+		inline void setCameraPosition(const Vector3D& cameraPosition);
 
 		/**
 		* @brief Gets the camera position
 		* @return the camera position
 		*/
-		const Vector3D& getCameraPosition();
+		inline const Vector3D& getCameraPosition();
 
 		///////////////
 		// Step Mode //
@@ -244,7 +244,7 @@ namespace SPK
 		* @param useClampStep : true to use a clamp value on the step, false not to
 		* @param clamp : the clamp value
 		*/
-		static void setClampStep(bool useClampStep,float clamp = 1.0f);
+		inline static void setClampStep(bool useClampStep,float clamp = 1.0f);
 
 		/**
 		* @brief Uses a constant step to update the systems
@@ -257,7 +257,7 @@ namespace SPK
 		* 
 		* @param constantStep : the value of the step
 		*/
-		static void useConstantStep(float constantStep);
+		inline static void useConstantStep(float constantStep);
 
 		/**
 		* @brief Uses an adaptive step to update the systems
@@ -273,7 +273,7 @@ namespace SPK
 		* @param minStep : the minimal time step
 		* @param maxStep : the maximal time step
 		*/
-		static void useAdaptiveStep(float minStep,float maxStep);
+		inline static void useAdaptiveStep(float minStep,float maxStep);
 
 		/**
 		* @brief Uses the real step to update the systems
@@ -284,13 +284,13 @@ namespace SPK
 		* This mode is the simpler and the one that allows best performance on low end systems.<br>
 		* However the update may be inaccurate (due to too big deltaTime) and it performs badly with frame rate variation.
 		*/
-		static void useRealStep();
+		inline static void useRealStep();
 
 		/**
 		* @brief Gets the current step mode
 		* @return the current step mode
 		*/
-		static StepMode getStepMode();
+		inline static StepMode getStepMode();
 
 		//////////
 		// Misc //
@@ -302,10 +302,10 @@ namespace SPK
 		* A system is active if at least one of its inner groups is active
 		* A group is active if it has at least one particle or one active emitter
 		*/
-		bool isActive() const;
+		inline bool isActive() const;
 
 		void initialize();
-		bool isInitialized() const;
+		inline bool isInitialized() const;
 
 		virtual Ref<SPKObject> findByName(const std::string& name);
 		

--- a/include/Core/SPK_Transformable.h
+++ b/include/Core/SPK_Transformable.h
@@ -36,14 +36,14 @@ namespace SPK
 		* @brief Gets the transform of this transformable
 		* @return the transform of this transformable
 		*/
-		Transform& getTransform();
+		inline Transform& getTransform();
 
 		/**
 		* @brief Gets the transform of this transformable
 		* This is the const version of getTransform()
 		* @return the transform of this transformable
 		*/
-		const Transform& getTransform() const;
+		inline const Transform& getTransform() const;
 
 		/**
 		* @brief Updates the transform of this transformable
@@ -55,12 +55,12 @@ namespace SPK
 		// Transform helpers //
 		///////////////////////
 		/// TODO: See Transform
-		void setTransformPosition(const Vector3D& pos);
-		const Vector3D& getTransformPosition() const;
-		void setTransformLookLH(const Vector3D& pos);
-		const Vector3D& getTransformLookLH() const;
-		void setTransformUp(const Vector3D& pos);
-		const Vector3D& getTransformUp() const;
+		inline void setTransformPosition(const Vector3D& pos);
+		inline const Vector3D& getTransformPosition() const;
+		inline void setTransformLookLH(const Vector3D& pos);
+		inline const Vector3D& getTransformLookLH() const;
+		inline void setTransformUp(const Vector3D& pos);
+		inline const Vector3D& getTransformUp() const;
 
 	public:
 		spark_description( Transformable, SPKObject )
@@ -99,14 +99,14 @@ namespace SPK
 		* @param tPos : the transformed position
 		* @param pos : the position to transform
 		*/
-		void transformPos(Vector3D& tPos,const Vector3D& pos);
+		inline void transformPos(Vector3D& tPos,const Vector3D& pos);
 
 		/**
 		* @brief Transforms a direction in this object's space
 		* @param tPos : the transformed direction
 		* @param pos : the direction to transform
 		*/
-		void transformDir(Vector3D& tDir,const Vector3D& dir);
+		inline void transformDir(Vector3D& tDir,const Vector3D& dir);
 
 	private :
 

--- a/include/Core/SPK_Zone.h
+++ b/include/Core/SPK_Zone.h
@@ -68,9 +68,9 @@ namespace SPK
 		// Position //
 		//////////////
 
-		void setPosition(const Vector3D& position);
-		const Vector3D& getPosition() const;
-		const Vector3D& getTransformedPosition() const;
+		inline void setPosition(const Vector3D& position);
+		inline const Vector3D& getPosition() const;
+		inline const Vector3D& getTransformedPosition() const;
 
 		///////////////
 		// Interface //
@@ -88,7 +88,7 @@ namespace SPK
 		* @param normal : A pointer to a vector used to store the normal (if NULL, the normal wont be computed)
 		* @return true if the test is fullfilled, false otherwise
 		*/
-		bool check(const Particle& particle,ZoneTest zoneTest,Vector3D* normal = NULL) const;
+		inline bool check(const Particle& particle,ZoneTest zoneTest,Vector3D* normal = NULL) const;
 
 	public :
 		spark_description(Zone, Transformable)
@@ -100,8 +100,8 @@ namespace SPK
 
 		Zone(const Vector3D& position = Vector3D());
 
-		virtual  void innerUpdateTransform();
-		static  void normalizeOrRandomize(Vector3D& v);
+		inline virtual  void innerUpdateTransform();
+		inline static  void normalizeOrRandomize(Vector3D& v);
 
 	private :
 

--- a/include/Core/SPK_ZonedModifier.h
+++ b/include/Core/SPK_ZonedModifier.h
@@ -52,7 +52,7 @@ namespace SPK
 		* @param zone : the zone
 		* @param zoneTest : the zone test
 		*/
-		void setZone(const Ref<Zone>& zone, ZoneTest zoneTest);
+		inline void setZone(const Ref<Zone>& zone, ZoneTest zoneTest);
 
 		/**
 		* @brief Sets the zone
@@ -67,7 +67,7 @@ namespace SPK
 		* @brief Gets the zone
 		* @return the zone
 		*/
-		const Ref<Zone>& getZone() const;
+		inline const Ref<Zone>& getZone() const;
 
 		/**
 		* @brief Sets the zone test
@@ -83,7 +83,7 @@ namespace SPK
 		* @brief Gets the zone test
 		* @return the zone test
 		*/
-		ZoneTest getZoneTest() const;
+		inline ZoneTest getZoneTest() const;
 
 		///////////////////////
 		// Virtual interface //
@@ -126,7 +126,7 @@ namespace SPK
 		* @brief Check whether the zone test passes for a given particle
 		* @return true is the zone test passes, false if not
 		*/
-		bool checkZone(const Particle& particle,Vector3D* normal = NULL) const;
+		inline bool checkZone(const Particle& particle,Vector3D* normal = NULL) const;
 
 		virtual void propagateUpdateTransform();
 

--- a/include/Extensions/Actions/SPK_ActionSet.h
+++ b/include/Extensions/Actions/SPK_ActionSet.h
@@ -37,7 +37,7 @@ namespace SPK
 		void addAction(const Ref<Action>& action);
 		void removeAction(const Ref<Action>& action);
 		const Ref<Action>& getAction(size_t index) const;
-		size_t getNbActions() const;
+		inline size_t getNbActions() const;
 		void clearActions();
 
 		virtual void apply(Particle& particle) const;

--- a/include/Extensions/Actions/SPK_SpawnParticlesAction.h
+++ b/include/Extensions/Actions/SPK_SpawnParticlesAction.h
@@ -81,13 +81,13 @@ namespace SPK
 		* @brief Gets the minimum number of particles to spawn
 		* @return the minimum number of particles to spawn
 		*/
-		unsigned int getMinNb() const;
+		inline unsigned int getMinNb() const;
 
 		/**
 		* @brief Gets the maximum number of particles to spawn
 		* @return the maximum number of particles to spawn
 		*/
-		unsigned int getMaxNb() const;
+		inline unsigned int getMaxNb() const;
 
 		//////////////////
 		// Base emitter //
@@ -106,7 +106,7 @@ namespace SPK
 		* If the base emitter is modified, a call to resetPool() will allow the changes to take effects
 		* @return the base emitter
 		*/
-		const Ref<Emitter>& getEmitter() const;
+		inline const Ref<Emitter>& getEmitter() const;
 
 		/////////////////
 		// Group index //
@@ -118,13 +118,13 @@ namespace SPK
 		* Note that setting the group index to the index of the group which owns the spawn particle action may result in infinitely growing group.
 		* @param index : the index of the group in the parent system in which to spawn particles
 		*/
-		void setTargetGroup(const Ref<Group>& group);
+		inline void setTargetGroup(const Ref<Group>& group);
 
 		/**
 		* @brief Gets the index of the group within the parent system in which to spawn particles
 		* @return the index of the group in which to spawn particles
 		*/
-		const Ref<Group>& getTargetGroup() const;
+		inline const Ref<Group>& getTargetGroup() const;
 
 		///////////////
 		// Interface //

--- a/include/Extensions/Emitters/SPK_NormalEmitter.h
+++ b/include/Extensions/Emitters/SPK_NormalEmitter.h
@@ -66,19 +66,19 @@ namespace SPK
 		* @brief Gets the normal zone of this normalEmitter
 		* @return the normal zone of this normalEmitter
 		*/
-		const Ref<Zone>& getNormalZone() const;
+		inline const Ref<Zone>& getNormalZone() const;
 
 		/**
 		* @brief Sets whether normals are inverted or not
 		* @param inverted true to use inverted normals, false not to
 		*/
-		void setInverted(bool inverted);
+		inline void setInverted(bool inverted);
 
 		/**
 		* @brief Tells whether normals are inverted for this normalEmitter
 		* @return true if normals are inverted, false if not
 		*/
-		bool isInverted() const;
+		inline bool isInverted() const;
 
 		/////////////
 		// Herited //

--- a/include/Extensions/Emitters/SPK_SphericEmitter.h
+++ b/include/Extensions/Emitters/SPK_SphericEmitter.h
@@ -78,7 +78,7 @@ namespace SPK
 		* @brief Gets the direction of this SphericEmitter
 		* @return the direction of this SphericEmitter
 		*/
-		const Vector3D& getDirection() const;
+		inline const Vector3D& getDirection() const;
 
 		/**
 		* @brief Gets the direction of this SphericEmitter
@@ -100,13 +100,13 @@ namespace SPK
 		* @brief Gets the minimum angle of this SphericEmitter
 		* @return the minimum angle of this SphericEmitter
 		*/
-		float getAngleMin() const;
+		inline float getAngleMin() const;
 
 		/**
 		* @brief Gets the maximum angle of this SphericEmitter
 		* @return the maximum angle of this SphericEmitter
 		*/
-		float getAngleMax() const;
+		inline float getAngleMax() const;
 
 	public :
 		spark_description(SphericEmitter, Emitter)

--- a/include/Extensions/Emitters/SPK_StraightEmitter.h
+++ b/include/Extensions/Emitters/SPK_StraightEmitter.h
@@ -59,7 +59,7 @@ namespace SPK
 		* @brief Gets the direction of this StraightEmitter
 		* @return the direction of this StraightEmitter
 		*/
-		const Vector3D& getDirection() const;
+		inline const Vector3D& getDirection() const;
 
 		/**
 		* @brief Gets the transformed direction of this StraightEmitter

--- a/include/Extensions/Modifiers/SPK_BasicModifiers.h
+++ b/include/Extensions/Modifiers/SPK_BasicModifiers.h
@@ -30,8 +30,8 @@ namespace SPK
 
 		static  Ref<Gravity> create(const Vector3D& value = Vector3D());
 
-		void setValue(const Vector3D& value);
-		const Vector3D& getValue() const;
+		inline void setValue(const Vector3D& value);
+		inline const Vector3D& getValue() const;
 		const Vector3D& getTransformedValue() const;
 
 	public :

--- a/include/Extensions/Modifiers/SPK_Collider.h
+++ b/include/Extensions/Modifiers/SPK_Collider.h
@@ -79,7 +79,7 @@ namespace SPK
 		* @brief Gets the elasticity of the collisions
 		* @return the elasticity of the collisions
 		*/
-		float getElasticity() const;
+		inline float getElasticity() const;
 
 	public :
 		spark_description(Collider, Modifier)

--- a/include/Extensions/Modifiers/SPK_EmitterAttacher.h
+++ b/include/Extensions/Modifiers/SPK_EmitterAttacher.h
@@ -38,16 +38,16 @@ namespace SPK
 
 		~EmitterAttacher();
 
-		void setEmitter(const Ref<Emitter>& emitter);
-		const Ref<Emitter>& getEmitter() const;
+		inline void setEmitter(const Ref<Emitter>& emitter);
+		inline const Ref<Emitter>& getEmitter() const;
 
-		void setTargetGroup(const Ref<Group>& group);
-		const Ref<Group>& getTargetGroup() const;
+		inline void setTargetGroup(const Ref<Group>& group);
+		inline const Ref<Group>& getTargetGroup() const;
 
-		void enableEmitterOrientation(bool o);
-		void enableEmitterRotation(bool r);
-		bool isEmitterOrientationEnabled() const;
-		bool isEmitterRotationEnabled() const;
+		inline void enableEmitterOrientation(bool o);
+		inline void enableEmitterRotation(bool r);
+		inline bool isEmitterOrientationEnabled() const;
+		inline bool isEmitterRotationEnabled() const;
 
 	public :
 		spark_description(EmitterAttacher, Modifier)

--- a/include/Extensions/Modifiers/SPK_LinearForce.h
+++ b/include/Extensions/Modifiers/SPK_LinearForce.h
@@ -118,13 +118,13 @@ namespace SPK
 		* The value of the force is a vector defining a direction and its norm defines the power of the force
 		* @param value : the value of the force
 		*/
-		void setValue(const Vector3D& value);
+		inline void setValue(const Vector3D& value);
 
 		/**
 		* @brief Gets the value of the force
 		* @return the value of the force
 		*/
-		const Vector3D& getValue() const;
+		inline const Vector3D& getValue() const;
 
 		/**
 		* @brief Gets the transformed value of the force
@@ -151,14 +151,14 @@ namespace SPK
 		* @param squaredSpeed : true to use squared speed, false to use speed
 		*/
 		void setRelative(bool relative, bool squaredSpeed);
-		void setRelative(bool relative);
-		void setUseSquaredSpeed(bool u);
+		inline void setRelative(bool relative);
+		inline void setUseSquaredSpeed(bool u);
 
 		/**
 		* @brief Tells whether this force is relative to the particle's velocity
 		* @return true if the force is relative, false if not
 		*/
-		bool isRelative() const;
+		inline bool isRelative() const;
 
 		/**
 		* @brief Tells whether squared relative speed is used to deduce the discrete force
@@ -166,7 +166,7 @@ namespace SPK
 		* approximation of the reality
 		* @return true if the squared relative speed is used, false otherwise
 		*/
-		bool isSquaredSpeedUsed() const;
+		inline bool isSquaredSpeedUsed() const;
 
 		///////////////
 		// Parameter //
@@ -192,21 +192,21 @@ namespace SPK
 		* @param factor : the degree of the parameter
 		*/
 		void setParam(Param param, Factor factor);
-		void setParam(Param param);
+		inline void setParam(Param param);
 
-		void setFactor(Factor factor);
+		inline void setFactor(Factor factor);
 
 		/**
 		* @brief Gets the parameter used to modulate the force
 		* @return the parameter used to modulate the force 
 		*/
-		Param getParam() const;
+		inline Param getParam() const;
 
 		/**
 		* @brief Gets the degree of the parameter used
 		* @return the degree of the parameter used
 		*/
-		Factor getFactor() const;
+		inline Factor getFactor() const;
 
 		/////////////////
 		// Coefficient //
@@ -216,13 +216,13 @@ namespace SPK
 		* @brief Sets the constant by which is multiplied the force
 		* @param coef : the constant by which is multiplied the force
 		*/
-		void setCoef(float coef);
+		inline void setCoef(float coef);
 
 		/**
 		* @brief Gets the constant by which is multiplied the force
 		* @return the constant by which is multiplied the force 
 		*/
-		float getCoef() const;
+		inline float getCoef() const;
 
 		//////////////
 		// Helpers //

--- a/include/Extensions/Modifiers/SPK_Obstacle.h
+++ b/include/Extensions/Modifiers/SPK_Obstacle.h
@@ -45,13 +45,13 @@ namespace SPK
 		*
 		* @param bouncingRatio : the bouncing ratio of this obstacle
 		*/
-		void setBouncingRatio(float bouncingRatio);
+		inline void setBouncingRatio(float bouncingRatio);
 
 			/**
 		* @brief Gets the bouncing ratio of this obstacle
 		* @return the bouncing ratio of this obstacle
 		*/
-		float getBouncingRatio() const;
+		inline float getBouncingRatio() const;
 
 		//////////////
 		// Friction //
@@ -64,13 +64,13 @@ namespace SPK
 		*
 		* @param friction : the friction of this obstacle
 		*/
-		void setFriction(float friction);
+		inline void setFriction(float friction);
 
 		/**
 		* @brief Gets the friction of this obstacle
 		* @return the friction of this obstacle
 		*/
-		float getFriction() const;
+		inline float getFriction() const;
 
 	public :
 		spark_description(Obstacle, ZonedModifier)

--- a/include/Extensions/Modifiers/SPK_PointMass.h
+++ b/include/Extensions/Modifiers/SPK_PointMass.h
@@ -52,13 +52,13 @@ namespace SPK
 		* @brief Sets the position of the point mass
 		* @param pos : the position
 		*/
-		void setPosition(const Vector3D& pos);
+		inline void setPosition(const Vector3D& pos);
 
 		/**
 		* @brief Gets the position of the point mass
 		* @return the position
 		*/
-		const Vector3D& getPosition() const;
+		inline const Vector3D& getPosition() const;
 
 		/**
 		* @brief Gets the transformed position of the point mass
@@ -79,13 +79,13 @@ namespace SPK
 		*
 		* @param mass : the mass
 		*/
-		void setMass(float mass);
+		inline void setMass(float mass);
 
 		/**
 		* @brief Gets the mass of the point mass
 		* @return the mass
 		*/
-		float getMass() const;
+		inline float getMass() const;
 
 		////////////
 		// Offset //
@@ -107,7 +107,7 @@ namespace SPK
 		* @brief Gets the offset of the point mass
 		* @return the offset
 		*/
-		float getOffset() const;
+		inline float getOffset() const;
 
 	public :
 		spark_description(PointMass, Modifier)

--- a/include/Extensions/Modifiers/SPK_RandomForce.h
+++ b/include/Extensions/Modifiers/SPK_RandomForce.h
@@ -69,13 +69,13 @@ namespace SPK
 		* @brief Gets the min vector
 		* @return the min vector
 		*/
-		const Vector3D& getMinVector() const;
+		inline const Vector3D& getMinVector() const;
 
 		/**
 		* @brief Gets the max vector
 		* @return the max vector
 		*/
-		const Vector3D& getMaxVector() const;
+		inline const Vector3D& getMaxVector() const;
 
 		/**
 		* @brief Gets the transformed min vector
@@ -109,13 +109,13 @@ namespace SPK
 		* @brief Gets the minimal period
 		* @return the minimal period
 		*/
-		float getMinPeriod() const;
+		inline float getMinPeriod() const;
 
 		/**
 		* @brief Gets the maximal period
 		* @return the maximal period
 		*/
-		float getMaxPeriod() const;
+		inline float getMaxPeriod() const;
 
 	public :
 		spark_description(RandomForce, Modifier)

--- a/include/Extensions/Modifiers/SPK_Vortex.h
+++ b/include/Extensions/Modifiers/SPK_Vortex.h
@@ -71,13 +71,13 @@ namespace SPK
 		*
 		* @param position : the position of the eye of the vortex
 		*/
-		void setPosition(const Vector3D& position);
+		inline void setPosition(const Vector3D& position);
 
 		/**
 		* @brief Gets the position of the eye
 		* @return the position of the eye
 		*/
-		const Vector3D& getPosition() const;
+		inline const Vector3D& getPosition() const;
 
 		/**
 		* @brief Gets the transformed position of the eye
@@ -93,13 +93,13 @@ namespace SPK
 		*
 		* @param dir : the direction of the eye of the vortex
 		*/
-		void setDirection(const Vector3D& dir);
+		inline void setDirection(const Vector3D& dir);
 
 		/**
 		* @brief Gets the direction of the eye
 		* @return the direction of the eye (normalized)
 		*/
-		const Vector3D& getDirection() const;
+		inline const Vector3D& getDirection() const;
 
 		/**
 		* @brief Gets the transformed direction of the eye
@@ -120,7 +120,7 @@ namespace SPK
 		* @brief Returns the eye radius
 		* @return the eye radius
 		*/
-		float getEyeRadius() const;
+		inline float getEyeRadius() const;
 
 		////////////
 		// Speeds //
@@ -139,21 +139,21 @@ namespace SPK
 		* @param rotationSpeed : the speed of rotation (either in units per unit of time or in radians per unit of time dependent on the second parameter)
 		* @param angular :  true to have the rotation in radians per unit of time, false to have it in unit per unit of time.
 		*/
-		void setRotationSpeed(float rotationSpeed, bool angular);
-		void setRotationSpeed(float rotationSpeed);
-		void setRotationSpeedAngular(bool a);
+		inline void setRotationSpeed(float rotationSpeed, bool angular);
+		inline void setRotationSpeed(float rotationSpeed);
+		inline void setRotationSpeedAngular(bool a);
 
 		/**
 		* @brief Gets the rotation speed
 		* @return the rotation speed
 		*/
-		float getRotationSpeed() const;
+		inline float getRotationSpeed() const;
 
 		/**
 		* @brief Tells whether rotation speed is angular
 		* @return true if rotation speed is angular, false if not
 		*/
-		bool isRotationSpeedAngular() const;
+		inline bool isRotationSpeedAngular() const;
 
 		/**
 		* @brief Sets the attraction speed of the vortex
@@ -171,20 +171,20 @@ namespace SPK
 		* @param linear : true to set the speed function of the distance from the eye, false to set it constant
 		*/
 		void setAttractionSpeed(float attractionSpeed, bool linear);
-		void setAttractionSpeed(float attractionSpeed);
-		void setAttractionSpeedLinear(bool l);
+		inline void setAttractionSpeed(float attractionSpeed);
+		inline void setAttractionSpeedLinear(bool l);
 
 		/**
 		* @brief Gets the attraction speed
 		* @return the attraction speed
 		*/
-		float getAttractionSpeed() const;
+		inline float getAttractionSpeed() const;
 
 		/**
 		* @brief Tells whether attraction speed is function of the distance from the eye
 		* @return true if attraction speed is linear, false if it is constant
 		*/
-		bool isAttractionSpeedLinear() const;
+		inline bool isAttractionSpeedLinear() const;
 
 		///////////////////////
 		// Killing particles //
@@ -194,13 +194,13 @@ namespace SPK
 		* @brief Tells whether particles is the eye must be killed or not
 		* @param kill : true to kill particles in the eye, false not to
 		*/
-		void enableParticleKilling(bool kill);
+		inline void enableParticleKilling(bool kill);
 
 		/**
 		* @brief Tells whether particles are killed when in the eye
 		* @return true if particles are killed in the eye, false if not
 		*/
-		bool isParticleKillingEnabled() const;
+		inline bool isParticleKillingEnabled() const;
 
 	public :
 		spark_description(Vortex, Modifier)

--- a/include/Extensions/Zones/SPK_Cylinder.h
+++ b/include/Extensions/Zones/SPK_Cylinder.h
@@ -34,8 +34,8 @@ namespace SPK
 			float radius = 1.0f,
 			const Vector3D& axis = Vector3D(0.0f,1.0f,0.0f));
 
-		void setHeight(float h);
-		void setRadius(float r);
+		inline void setHeight(float h);
+		inline void setRadius(float r);
 		float getHeight() const	{ return height; }
 		float getRadius() const	{ return radius; }
 

--- a/include/Extensions/Zones/SPK_Plane.h
+++ b/include/Extensions/Zones/SPK_Plane.h
@@ -71,7 +71,7 @@ namespace SPK
 		* @brief Gets the normal of this Plane
 		* @return the normal of this Plane
 		*/
-		const Vector3D& getNormal() const;
+		inline const Vector3D& getNormal() const;
 
 		/**
 		* @brief Gets the transformed normal of this Plane

--- a/include/Extensions/Zones/SPK_Ring.h
+++ b/include/Extensions/Zones/SPK_Ring.h
@@ -76,7 +76,7 @@ namespace SPK
 		* @brief Gets the normal of this ring
 		* @return the normal of this ring
 		*/
-		const Vector3D& getNormal() const;
+		inline const Vector3D& getNormal() const;
 
 		/**
 		* @brief Gets the transformed normal of this ring
@@ -102,13 +102,13 @@ namespace SPK
 		* @brief Gets the minimum radius of this ring
 		* @return the minimum radius of this ring
 		*/
-		float getMinRadius() const;
+		inline float getMinRadius() const;
 
 		/**
 		* @brief Gets the maximum radius of this ring
 		* @return the maximum radius of this ring
 		*/
-		float getMaxRadius() const;
+		inline float getMaxRadius() const;
 
 		///////////////
 		// Interface //

--- a/include/Extensions/Zones/SPK_Sphere.h
+++ b/include/Extensions/Zones/SPK_Sphere.h
@@ -35,7 +35,7 @@ namespace SPK
 		////////////
 
 		void setRadius(float radius);
-		float getRadius() const;
+		inline float getRadius() const;
 
 		///////////////
 		// Interface //


### PR DESCRIPTION
On mingw64, functions that have a dllimport attribute and are inline functions,
need to have the inline specifier on both the definition and declaration when
they are present in the same header file.
Otherwise the following warning appears:

```
spark/include/Extensions/Modifiers/SPK_EmitterAttacher.h:132:36: warning: 'const SPK::Ref<SPK::Emitter>& SPK::EmitterAttacher::getEmitter() const' redeclared without dllimport attribute after being referenced with dll linkage
  132 |         inline const Ref<Emitter>& EmitterAttacher::getEmitter() const
      |                                    ^~~~~~~~~~~~~~~
```